### PR TITLE
Partial implementation of `tslmt2tsl`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
+*.tsl
+TODO
 .DS_Store
+tags
 dist
 dist-newstyle
 cabal-dev
@@ -16,6 +19,7 @@ cabal.sandbox.config
 *.prof
 *.aux
 *.hp
+tslmt2tsl
 tsl2tlsf
 tslcheck
 tslsize

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ TSLMINREAL=tslminrealizable
 PARSEHOA=parsehoa
 HOA2CODE=hoa2code
 TSLSYNTH=tslsynth
+TSLMT2TSL=tslmt2tsl
 
 TOOLS=\
   ${TSLCHECK}\
@@ -33,7 +34,8 @@ TOOLS=\
   ${TSLMINREAL}\
   ${PARSEHOA}\
   ${HOA2CODE}\
-  ${TSLSYNTH}
+  ${TSLSYNTH}\
+  ${TSLMT2TSL}
 
 STACKPATH=$(shell if [ -d "dist" ]; then echo ""; else stack path | grep local-install-root | sed 's/local-install-root: //'; fi)
 BLDTOOL=$(shell if [ -d "dist" ]; then echo "cabal"; else echo "stack"; fi)
@@ -110,8 +112,9 @@ ${TSLSYNTH}:
 	${BLDTOOL} build :$@
 	@if [ -d "dist" ]; then cp ./dist/build/$@/$@ $@; else cp ${STACKPATH}/bin/$@ $@; fi
 
-
-
+${TSLMT2TSL}:
+	${BLDTOOL} build :$@
+	@if [ -d "dist" ]; then cp ./dist/build/$@/$@ $@; else cp ${STACKPATH}/bin/$@ $@; fi
 
 install:
 	${BLDTOOL} install

--- a/docs/tslmt.md
+++ b/docs/tslmt.md
@@ -1,8 +1,8 @@
 # Temporal Stream Logic Modulo Theories
 
-Synthesis support for [Temporal Stream Logic Modulo Theories (TSL-MT)](https://link.springer.com/chapter/10.1007/978-3-030-99253-8_17) is given according to the paper [Can Reactive Synthesis and Syntax-Guided Synthesis Be Friends?](https://www.marksantolucito.com/papers/pldi2022.pdf).
+Synthesis support for [Temporal Stream Logic Modulo Theories (TSL-MT)](https://link.springer.com/chapter/10.1007/978-3-030-99253-8_17) is given according to the paper "[Can Reactive Synthesis and Syntax-Guided Synthesis Be Friends?](https://www.marksantolucito.com/papers/pldi2022.pdf)".
 
-In order to specify a TSL-MT specification, name the theory at the top of the file with a `#`.
+In order to specify a TSL-MT specification, define the appropriate first-order theory at the top of the file with a `#`.
 For instance, the example in the Introduction of the paper can be specified as follows:
 
 ```
@@ -14,30 +14,31 @@ always guarantee {
 ```
 
 For backwards compatibility, all TSL specifications without an explicit First-Order Theory will be synthesized without theory support.
-However, as the original Temporal Stream Logic is just TSL-MT with the Theory of Uninterpreted Functions, a `#UF` annotation is recommended.
-This allows TSL specifications (equivalently, TSL Modulo the Theory of Uninterpreted Functions) to _not_ underapproximate to Linear Temporal Logic (LTL) as given in the [original TSL paper](https://www.marksantolucito.com/papers/cav-19.pdf) but instead capture of the semantics of the update operator. 
+However, as classic TSL is just TSL-MT with the Theory of Uninterpreted Functions, a `#UF` annotation is recommended when writing a TSL specification.
+This allows TSL specifications (equivalently, TSL Modulo the Theory of Uninterpreted Functions) to _not underapproximate_ to Linear Temporal Logic (LTL) during synthesis as the TSL-MT synthesis procedure will capture the semantics of the update operator.
 More explanation is given in Example 4.3 of the [TSL-MT synthesis paper](https://www.marksantolucito.com/papers/pldi2022.pdf).
 
 ## Supported first-order theories
 `tsltools` can support all first-order theories that a SyGuS solver can solve.
-However, we currently only have support for the following, using [CVC5](https://cvc5.github.io/):
+However, we currently only have support for the following using [CVC5](https://cvc5.github.io/):
 
 * Uninterpreted Functions (UF)
 * Linear Integer Arithmetic (LIA): `eq`, `add`, `sub`
 
-Other first-order theories can be easily included in the system by simple parsing support.
+Other first-order theories can easily be included in the system by simple parsing support.
+Combining theories (e.g. with two or more first-order theories) should also be a straightforward extension.
 
 ## Flags
-Once you annotate the file with the first-order theory, `tsltools` will attempt to synthesize the specification with First-Order Theory support.
+Once you annotate the file with the first-order theory, `tsltools` will attempt to synthesize the specification with the relevant First-Order Theory support.
 However, if you want more diagnostic information, you can use the `--tslmt` flag and combine it with the following other flags:
-* `--tslmt --predicates`: Prints all the predicate literals and their dependent cells and output terminals in the specification.
+* `--tslmt --predicates`: Prints all the predicate literals and their dependent cells and output terminals.
 * `--tslmt --cfg`: Prints the possible Context-Free Grammar (CFG) for all cells and output terminals in the specification.
 * `--tslmt --consistency`: Prints all the consistency checking problems that can be obtained from the specification.
 * `--tslmt --consistency --solved`: Prints all the consistency checking problems, and if solved, prints the corresponding TSL assumption.
 * `--tslmt --dto`: Prints all the data transformation obligations that can be obtained from the specification.
 * `--tslmt --sygus`: Prints all the Syntax-Guided Synthesis problems that can be obtained from the specification.
 * `--tslmt --sygus --solved`: Prints all the Syntax-Guided Synthesis problems, and if solved, prints the corresponding TSL assumption.
-* `--tslmt --assumptions`: Prints all the assumptions that are generated from the synthesis procedure.
+* `--tslmt --assumptions`: Prints all the assumptions that are generated from the TSL-MT synthesis procedure.
 * `--tslmt --totsl`: Transforms a TSL-MT specification to a classic TSL specification, and prints the result.
 
 ## Limitations
@@ -57,13 +58,13 @@ Consider the following TSL-MT specification:
 ```
 always guarantee {
 	[var1 <- 4] && [var2 <- 5];
-	[eq (add var1 var2) 0 ] -> F [eq (add var1 var2) 9];
+	(eq (add var1 var2) 0 ) -> X [eq (add var1 var2) 9];
 }
 ```
 The correct environmental assumption learned from SyGuS should be 
 ```
 always assume {
-	((eq (add var1 var2) 0) && [var1 <- 4] && [var2 <- 5]) -> X (eq (add var1 var2) 9)
+	((eq (add var1 var2) 0) && [var1 <- 4] && [var2 <- 5]) -> X (eq (add var1 var2) 9);
 }
 ```
 However, since the algorithm only supports one single pure $\mathcal S$, this assumption cannot be generated.

--- a/docs/tslmt.md
+++ b/docs/tslmt.md
@@ -1,6 +1,6 @@
-# Temporal Stream Logic Modulo Theories
+# Temporal Stream Logic Modulo Theories (TSL-MT)
 
-Synthesis support for [Temporal Stream Logic Modulo Theories (TSL-MT)](https://link.springer.com/chapter/10.1007/978-3-030-99253-8_17) is given according to the paper "[Can Reactive Synthesis and Syntax-Guided Synthesis Be Friends?](https://www.marksantolucito.com/papers/pldi2022.pdf)".
+Synthesis support for [Temporal Stream Logic Modulo Theories (TSL-MT)](https://link.springer.com/chapter/10.1007/978-3-030-99253-8_17) is given by the tool `tslmt2tsl`, according to the paper "[Can Reactive Synthesis and Syntax-Guided Synthesis Be Friends?](https://www.marksantolucito.com/papers/pldi2022.pdf)".
 
 In order to specify a TSL-MT specification, define the appropriate first-order theory at the top of the file with a `#`.
 For instance, the example in the Introduction of the paper can be specified as follows:
@@ -23,33 +23,30 @@ More explanation is given in Example 4.3 of the [TSL-MT synthesis paper](https:/
 However, we currently only have support for the following using [CVC5](https://cvc5.github.io/):
 
 * Uninterpreted Functions (UF)
+* Uninterpreted Functions and Equality (UEF)
 * Linear Integer Arithmetic (LIA): `eq`, `add`, `sub`
 
 Other first-order theories can easily be included in the system by simple parsing support.
 Combining theories (e.g. with two or more first-order theories) should also be a straightforward extension.
 
 ## Flags
-Once you annotate the file with the first-order theory, `tsltools` will attempt to synthesize the specification with the relevant First-Order Theory support.
-However, if you want more diagnostic information, you can use the `--tslmt` flag and combine it with the following other flags:
-* `--tslmt --predicates`: Prints all the predicate literals and their dependent cells and output terminals.
-* `--tslmt --cfg`: Prints the possible Context-Free Grammar (CFG) for all cells and output terminals in the specification.
-* `--tslmt --consistency`: Prints all the consistency checking problems that can be obtained from the specification.
-* `--tslmt --consistency --solved`: Prints all the consistency checking problems, and if solved, prints the corresponding TSL assumption.
-* `--tslmt --dto`: Prints all the data transformation obligations that can be obtained from the specification.
-* `--tslmt --sygus`: Prints all the Syntax-Guided Synthesis problems that can be obtained from the specification.
-* `--tslmt --sygus --solved`: Prints all the Syntax-Guided Synthesis problems, and if solved, prints the corresponding TSL assumption.
-* `--tslmt --assumptions`: Prints all the assumptions that are generated from the TSL-MT synthesis procedure.
-* `--tslmt --totsl`: Transforms a TSL-MT specification to a classic TSL specification, and prints the result.
+Once you annotate the file with the first-order theory, `tslmt2tsl` will attempt to transform the TSL-MT specification to TSL.
+However, if you want more diagnostic information, you can use the following flags:
+* `--predicates`: Prints all the predicate literals and their dependent cells and output terminals.
+* `--cfg`: Prints the possible Context-Free Grammar (CFG) for all cells and output terminals in the specification.
+* `--consistency`: Prints all the consistency checking problems, and if solved, prints the corresponding TSL assumption.
+* `--sygus`: Prints all the Syntax-Guided Synthesis problems, and if solved, prints the corresponding TSL assumption.
+* `--assumptions`: Prints all the assumptions that are generated from the TSL-MT synthesis procedure.
 
 ## Limitations
-There are many limitations in synthesizing TSL-MT.
+There are many limitations in synthesizing TSL-MT with `tslmt2tsl`.
 The limitations can be categorized in three different types:
 
 ### Limitations of the tool
 * The temporal atom collection outlined in section 4.1 of the paper is substituted by an approximation.
 * The refinement loop given in section 4.4 is not fully implemented.
 ### Limitations of the dependencies
-* As noted in section 5.1, current (in 2022) state-of-the-art SyGuS solvers such as [CVC5 cannot synthesize recursive functions](https://github.com/cvc5/cvc5/issues/6182).
+* As noted in section 5.1, currently (in 2022) state-of-the-art SyGuS solvers such as [CVC5 cannot synthesize recursive functions](https://github.com/cvc5/cvc5/issues/6182).
 Therefore, Syntax-Guided Synthesis of a recursive function is replaced with an approximation.
 ### Limitations of the algorithm
 * Section 4.5 describes some limitations of the grammar, e.g. no support for nested conditionals.
@@ -61,7 +58,7 @@ always guarantee {
 	(eq (add var1 var2) 0 ) -> X [eq (add var1 var2) 9];
 }
 ```
-The correct environmental assumption learned from SyGuS should be 
+The desired environmental assumption is
 ```
 always assume {
 	((eq (add var1 var2) 0) && [var1 <- 4] && [var2 <- 5]) -> X (eq (add var1 var2) 9);

--- a/docs/tslmt.md
+++ b/docs/tslmt.md
@@ -1,0 +1,69 @@
+# Temporal Stream Logic Modulo Theories
+
+Synthesis support for [Temporal Stream Logic Modulo Theories (TSL-MT)](https://link.springer.com/chapter/10.1007/978-3-030-99253-8_17) is given according to the paper [Can Reactive Synthesis and Syntax-Guided Synthesis Be Friends?](https://www.marksantolucito.com/papers/pldi2022.pdf).
+
+In order to specify a TSL-MT specification, name the theory at the top of the file with a `#`.
+For instance, the example in the Introduction of the paper can be specified as follows:
+
+```
+#LIA
+always guarantee {
+	eq x 0 -> F (eq x 2);
+	[x <- add x 1] || [x <- sub x 1];
+}
+```
+
+For backwards compatibility, all TSL specifications without an explicit First-Order Theory will be synthesized without theory support.
+However, as the original Temporal Stream Logic is just TSL-MT with the Theory of Uninterpreted Functions, a `#UF` annotation is recommended.
+This allows TSL specifications (equivalently, TSL Modulo the Theory of Uninterpreted Functions) to _not_ underapproximate to Linear Temporal Logic (LTL) as given in the [original TSL paper](https://www.marksantolucito.com/papers/cav-19.pdf) but instead capture of the semantics of the update operator. 
+More explanation is given in Example 4.3 of the [TSL-MT synthesis paper](https://www.marksantolucito.com/papers/pldi2022.pdf).
+
+## Supported first-order theories
+`tsltools` can support all first-order theories that a SyGuS solver can solve.
+However, we currently only have support for the following, using [CVC5](https://cvc5.github.io/):
+
+* Uninterpreted Functions (UF)
+* Linear Integer Arithmetic (LIA): `eq`, `add`, `sub`
+
+Other first-order theories can be easily included in the system by simple parsing support.
+
+## Flags
+Once you annotate the file with the first-order theory, `tsltools` will attempt to synthesize the specification with First-Order Theory support.
+However, if you want more diagnostic information, you can use the `--tslmt` flag and combine it with the following other flags:
+* `--tslmt --predicates`: Prints all the predicate literals and their dependent cells and output terminals in the specification.
+* `--tslmt --cfg`: Prints the possible Context-Free Grammar (CFG) for all cells and output terminals in the specification.
+* `--tslmt --consistency`: Prints all the consistency checking problems that can be obtained from the specification.
+* `--tslmt --consistency --solved`: Prints all the consistency checking problems, and if solved, prints the corresponding TSL assumption.
+* `--tslmt --dto`: Prints all the data transformation obligations that can be obtained from the specification.
+* `--tslmt --sygus`: Prints all the Syntax-Guided Synthesis problems that can be obtained from the specification.
+* `--tslmt --sygus --solved`: Prints all the Syntax-Guided Synthesis problems, and if solved, prints the corresponding TSL assumption.
+* `--tslmt --assumptions`: Prints all the assumptions that are generated from the synthesis procedure.
+* `--tslmt --totsl`: Transforms a TSL-MT specification to a classic TSL specification, and prints the result.
+
+## Limitations
+There are many limitations in synthesizing TSL-MT.
+The limitations can be categorized in three different types:
+
+### Limitations of the tool
+* The temporal atom collection outlined in section 4.1 of the paper is substituted by an approximation.
+* The refinement loop given in section 4.4 is not fully implemented.
+### Limitations of the dependencies
+* As noted in section 5.1, current (in 2022) state-of-the-art SyGuS solvers such as [CVC5 cannot synthesize recursive functions](https://github.com/cvc5/cvc5/issues/6182).
+Therefore, Syntax-Guided Synthesis of a recursive function is replaced with an approximation.
+### Limitations of the algorithm
+* Section 4.5 describes some limitations of the grammar, e.g. no support for nested conditionals.
+* Similarly, the current procedure does not support simultaneous updates.
+Consider the following TSL-MT specification:
+```
+always guarantee {
+	[var1 <- 4] && [var2 <- 5];
+	[eq (add var1 var2) 0 ] -> F [eq (add var1 var2) 9];
+}
+```
+The correct environmental assumption learned from SyGuS should be 
+```
+always assume {
+	((eq (add var1 var2) 0) && [var1 <- 4] && [var2 <- 5]) -> X (eq (add var1 var2) 9)
+}
+```
+However, since the algorithm only supports one single pure $\mathcal S$, this assumption cannot be generated.

--- a/src/lib/TSL.hs
+++ b/src/lib/TSL.hs
@@ -67,6 +67,9 @@ module TSL
   , simulate
     -- * Error Handling
   , Error
+    -- * Modulo Theories
+  , CFG(..)
+  , fromSpec
   ) where
 
 -----------------------------------------------------------------------------
@@ -115,6 +118,8 @@ import TSL.Simulation (simulate)
 import TSL.TOML (toTOML)
 
 import TSL.CFM (CFM, fromCFM, statistics, symbolTable)
+
+import TSL.ModuloTheories.CFG(CFG(..), fromSpec)
 
 import qualified TSL.Writer.CFM.Clash as Clash (implement)
 import qualified TSL.Writer.CFM.Applicative as Applicative (implement)

--- a/src/lib/TSL/ModuloTheories/Assumptions.hs
+++ b/src/lib/TSL/ModuloTheories/Assumptions.hs
@@ -1,0 +1,23 @@
+-------------------------------------------------------------------------------
+-- |
+-- Module      :  TSL.ModuloTheories.CVC5
+-- Description :  Utilities to send SMT and SyGuS problems to CVC5.
+-- Maintainer  :  Wonhyuk Choi
+--
+-- Used for sending SMT and SyGuS problems to CVC5.
+
+-------------------------------------------------------------------------------
+{-# LANGUAGE LambdaCase      #-}
+{-# LANGUAGE RecordWildCards #-}
+
+{-
+   TODO:
+   * Send SMT/SyGuS problems to CVC5
+   * Parse results from CVC5
+   * Transform CVC5 results into some internal function representation
+-}
+
+-------------------------------------------------------------------------------
+module TSL.ModuloTheories.CVC5
+  ( 
+  ) where

--- a/src/lib/TSL/ModuloTheories/CFG.hs
+++ b/src/lib/TSL/ModuloTheories/CFG.hs
@@ -15,5 +15,44 @@
 
 -------------------------------------------------------------------------------
 module TSL.ModuloTheories.CFG
-  ( 
+  ( CFG(..)
+  , 
   ) where
+
+-------------------------------------------------------------------------------
+
+import TSL.Specification (Specification)
+
+import qualified Data.Sequence as Seq
+
+import Data.Sequence((!?), (><), Seq(..), (|>), fromList)
+
+-------------------------------------------------------------------------------
+
+type Id = Int
+
+data CFG = CFG
+    { -- | CFG implemented as a seq of lists.
+      -- To get the possible gramamrs for each,
+      -- index into the grammar with the signal Id.
+        grammar :: Seq.Seq [Formula Id]
+    , -- | Converts Id to name.
+        toName :: (Id -> String)
+    }
+
+fromSpec :: Specification -> CFG
+fromSpec (Specification a g s) =
+    CFG { grammar = buildGrammar
+        , toName = stName s
+        }
+
+-- TODO: just start out with static length
+buildGrammar :: [Formula Id] -> Seq.Seq [Formula Id]
+buildGrammar = buildGrammar' (Seq.fromList [])
+  where 
+    buildGrammar' acc []     = acc
+    buildGrammar' acc (x:xs) = 
+        \case x of
+          (Update dst src) -> undefined
+          -- TODO: append src to acc[dst]
+           _               -> undefined

--- a/src/lib/TSL/ModuloTheories/CFG.hs
+++ b/src/lib/TSL/ModuloTheories/CFG.hs
@@ -1,0 +1,19 @@
+-------------------------------------------------------------------------------
+-- |
+-- Module      :  TSL.ModuloTheories.CFG
+-- Description :  Builds a CFG for cells and outputs from the specification.
+-- Maintainer  :  Wonhyuk Choi
+--
+-- This module builds a Context-Free Grammar for cell and output signals
+-- from the original specification.
+-- This is necessary to build a Syntax-Guided Synthesis grammar when
+-- transforming a TSL-MT specification to TSL.
+
+-------------------------------------------------------------------------------
+{-# LANGUAGE LambdaCase      #-}
+{-# LANGUAGE RecordWildCards #-}
+
+-------------------------------------------------------------------------------
+module TSL.ModuloTheories.CFG
+  ( 
+  ) where

--- a/src/lib/TSL/ModuloTheories/CFG.hs
+++ b/src/lib/TSL/ModuloTheories/CFG.hs
@@ -16,43 +16,96 @@
 -------------------------------------------------------------------------------
 module TSL.ModuloTheories.CFG
   ( CFG(..)
-  , 
+  , fromSpec
   ) where
 
 -------------------------------------------------------------------------------
 
-import TSL.Specification (Specification)
+import TSL.Logic (Formula(..)
+                 , SignalTerm(..)
+                 , FunctionTerm(..)
+                 , PredicateTerm(..)
+                 )
 
-import qualified Data.Sequence as Seq
+import TSL.Specification (Specification(..))
 
-import Data.Sequence((!?), (><), Seq(..), (|>), fromList)
+import TSL.SymbolTable (SymbolTable(..), Kind(..))
+
+import Data.Array(Array, array, assocs, bounds, indices, (//), (!))
 
 -------------------------------------------------------------------------------
 
 type Id = Int
+type Grammar = Array Id [SignalTerm Id]
 
 data CFG = CFG
-    { -- | CFG implemented as a seq of lists.
-      -- To get the possible gramamrs for each,
-      -- index into the grammar with the signal Id.
-        grammar :: Seq.Seq [Formula Id]
-    , -- | Converts Id to name.
-        toName :: (Id -> String)
+    { -- | CFG implemented as an array of lists.
+      -- To get the possible production rules for each,
+      -- index into the grammar with the appropriate signal Id.
+        grammar :: Grammar
+    ,
+        symTable :: SymbolTable
     }
+
+instance Show CFG where
+    show (CFG g s) = 
+        unlines $ map show' $ filter (\(fst, _) -> isUpdate fst) $ assocs g
+      where
+        show' (id, rules)  = show (unhashId id) ++ " :\n" ++ show'' rules
+        show''             = unlines . (map (('\t':) . show . unhashS))
+        isUpdate idx       = (stKind s) idx == Output
+
+        unhashId                    = (stName s) 
+
+        unhashS (Signal s)          = unhashId s
+        unhashS (FunctionTerm f)    = unhashF f
+        unhashS (PredicateTerm p)   = unhashP p
+
+        unhashF (FunctionSymbol f)  = unhashId f
+        unhashF (FApplied f s)      = unhashF f ++ " " ++ unhashS s
+
+        unhashP BooleanTrue         = "True"
+        unhashP BooleanFalse        = "False"
+        unhashP (BooleanInput b)    = unhashId b
+        unhashP (PredicateSymbol p) = unhashId p
+        unhashP (PApplied p s)      = unhashP p ++ " " ++ unhashS s
 
 fromSpec :: Specification -> CFG
 fromSpec (Specification a g s) =
-    CFG { grammar = buildGrammar
-        , toName = stName s
+    CFG {
+            grammar     = buildGrammar (a ++ g) grammarInit
+        ,   symTable    = s
         }
+  where
+    symTableArr = symtable s
+    grammarInit = array (bounds symTableArr) emptyRules
+    emptyRules  = [(idx, []) | idx <- indices symTableArr]
 
--- TODO: just start out with static length
-buildGrammar :: [Formula Id] -> Seq.Seq [Formula Id]
-buildGrammar = buildGrammar' (Seq.fromList [])
-  where 
-    buildGrammar' acc []     = acc
-    buildGrammar' acc (x:xs) = 
-        \case x of
-          (Update dst src) -> undefined
-          -- TODO: append src to acc[dst]
-           _               -> undefined
+buildGrammar :: [Formula Id] -> Grammar -> Grammar
+buildGrammar [] g     = g
+buildGrammar (x:xs) g = buildGrammar xs (extendGrammar x g)
+
+-- | Adds new production rules to the grammar.
+extendGrammar :: Formula Id -> Grammar -> Grammar
+extendGrammar (Update dst src) oldGrammar = newGrammar
+  where
+    oldRules   = oldGrammar ! dst
+    newRules   = src:oldRules
+    newGrammar = oldGrammar // [(dst, newRules)]
+extendGrammar (Not f) g          = extendGrammar f g
+extendGrammar (Implies f h) g    = extendGrammar f (extendGrammar h g)
+extendGrammar (Equiv f h) g      = extendGrammar f (extendGrammar h g)
+extendGrammar (And (x:xs)) g     = extendGrammar (And xs) (extendGrammar x g)
+extendGrammar (Or (x:xs))  g     = extendGrammar (Or xs) (extendGrammar x g)
+extendGrammar (Next f) g         = extendGrammar f g
+extendGrammar (Previous f) g     = extendGrammar f g
+extendGrammar (Globally f) g     = extendGrammar f g
+extendGrammar (Finally f) g      = extendGrammar f g
+extendGrammar (Historically f) g = extendGrammar f g
+extendGrammar (Once f) g         = extendGrammar f g
+extendGrammar (Until f h) g      = extendGrammar f (extendGrammar h g)
+extendGrammar (Release f h) g    = extendGrammar f (extendGrammar h g)
+extendGrammar (Weak f h) g       = extendGrammar f (extendGrammar h g)
+extendGrammar (Since f h) g      = extendGrammar f (extendGrammar h g)
+extendGrammar (Triggered f h) g  = extendGrammar f (extendGrammar h g)
+extendGrammar _ g                = g

--- a/src/lib/TSL/ModuloTheories/CVC5.hs
+++ b/src/lib/TSL/ModuloTheories/CVC5.hs
@@ -1,0 +1,30 @@
+-------------------------------------------------------------------------------
+-- |
+-- Module      :  TSL.ModuloTheories.CVC5
+-- Description :  Utilities to send SMT and SyGuS problems to CVC5.
+-- Maintainer  :  Wonhyuk Choi
+--
+-- Used for sending SMT and SyGuS problems to CVC5.
+
+-------------------------------------------------------------------------------
+{-# LANGUAGE LambdaCase      #-}
+{-# LANGUAGE RecordWildCards #-}
+
+{-
+   TODO:
+   * Send SMT/SyGuS problems to CVC5
+   * Parse results from CVC5
+   * Transform CVC5 results into some internal function representation
+
+   N.B.
+   * This module should have EVERYTHING related to CVC5.
+   * _However_, it should not have String -> SMTLib or String -> SyGuS2.0 functions,
+   since those are not necessarily tied to CVC5.
+   * Those functions should live in their respective modules,
+   i.e. Sygus.hs and ConsistencyChecking.hs.
+-}
+
+-------------------------------------------------------------------------------
+module TSL.ModuloTheories.CVC5
+  ( 
+  ) where

--- a/src/lib/TSL/ModuloTheories/ConsistencyChecking.hs
+++ b/src/lib/TSL/ModuloTheories/ConsistencyChecking.hs
@@ -1,0 +1,19 @@
+-------------------------------------------------------------------------------
+-- |
+-- Module      :  TSL.ModuloTheories.CFG
+-- Description :  Builds a CFG for cells and outputs from the specification.
+-- Maintainer  :  Wonhyuk Choi
+--
+-- This module builds a Context-Free Grammar for cell and output signals
+-- from the original specification.
+-- This is necessary to build a Syntax-Guided Synthesis grammar when
+-- transforming a TSL-MT specification to TSL.
+
+-------------------------------------------------------------------------------
+{-# LANGUAGE LambdaCase      #-}
+{-# LANGUAGE RecordWildCards #-}
+
+-------------------------------------------------------------------------------
+module TSL.ModuloTheories.CFG
+  ( 
+  ) where

--- a/src/lib/TSL/ModuloTheories/PredicateList.hs
+++ b/src/lib/TSL/ModuloTheories/PredicateList.hs
@@ -1,0 +1,19 @@
+-------------------------------------------------------------------------------
+-- |
+-- Module      :  TSL.ModuloTheories.CFG
+-- Description :  Builds a CFG for cells and outputs from the specification.
+-- Maintainer  :  Wonhyuk Choi
+--
+-- This module builds a Context-Free Grammar for cell and output signals
+-- from the original specification.
+-- This is necessary to build a Syntax-Guided Synthesis grammar when
+-- transforming a TSL-MT specification to TSL.
+
+-------------------------------------------------------------------------------
+{-# LANGUAGE LambdaCase      #-}
+{-# LANGUAGE RecordWildCards #-}
+
+-------------------------------------------------------------------------------
+module TSL.ModuloTheories.CFG
+  ( 
+  ) where

--- a/src/lib/TSL/ModuloTheories/Sygus.hs
+++ b/src/lib/TSL/ModuloTheories/Sygus.hs
@@ -1,0 +1,23 @@
+-------------------------------------------------------------------------------
+-- |
+-- Module      :  TSL.ModuloTheories.CVC5
+-- Description :  Utilities to send SMT and SyGuS problems to CVC5.
+-- Maintainer  :  Wonhyuk Choi
+--
+-- Used for sending SMT and SyGuS problems to CVC5.
+
+-------------------------------------------------------------------------------
+{-# LANGUAGE LambdaCase      #-}
+{-# LANGUAGE RecordWildCards #-}
+
+{-
+   TODO:
+   * Send SMT/SyGuS problems to CVC5
+   * Parse results from CVC5
+   * Transform CVC5 results into some internal function representation
+-}
+
+-------------------------------------------------------------------------------
+module TSL.ModuloTheories.CVC5
+  ( 
+  ) where

--- a/src/lib/TSL/ModuloTheories/Theories.hs
+++ b/src/lib/TSL/ModuloTheories/Theories.hs
@@ -1,0 +1,23 @@
+-------------------------------------------------------------------------------
+-- |
+-- Module      :  TSL.ModuloTheories.CVC5
+-- Description :  Utilities to send SMT and SyGuS problems to CVC5.
+-- Maintainer  :  Wonhyuk Choi
+--
+-- Used for sending SMT and SyGuS problems to CVC5.
+
+-------------------------------------------------------------------------------
+{-# LANGUAGE LambdaCase      #-}
+{-# LANGUAGE RecordWildCards #-}
+
+{-
+   TODO:
+   * Send SMT/SyGuS problems to CVC5
+   * Parse results from CVC5
+   * Transform CVC5 results into some internal function representation
+-}
+
+-------------------------------------------------------------------------------
+module TSL.ModuloTheories.CVC5
+  ( 
+  ) where

--- a/src/lib/TSL/Specification.hs
+++ b/src/lib/TSL/Specification.hs
@@ -36,6 +36,12 @@ data Specification =
     }
 
 -----------------------------------------------------------------------------
+instance Show Specification where
+    show (Specification a g s) = "Assumptions\n:" ++ stringify a ++ "\nGuarantees:\n" ++ stringify g
+        where 
+            getName    = fmap (stName s)
+            stringify  = unlines . (map (show . getName))
+-----------------------------------------------------------------------------
 
 -- | Create one formula out of assumptions and guarantees.
 --   TODO, look into this. 

--- a/src/tools/tslsym/Main.hs
+++ b/src/tools/tslsym/Main.hs
@@ -31,8 +31,6 @@ import Data.List (isInfixOf, partition)
 
 import Control.Monad (when)
 
-import Debug.Trace (trace)
-
 -----------------------------------------------------------------------------
 
 main
@@ -45,7 +43,7 @@ main = do
 
   spec <- loadTSL input
   let
-    table = toCSV $ symboltable $ trace (show spec) spec
+    table = toCSV $ symboltable spec
     (is,ts') = partition (isInfixOf "internal") es
     (h':es) = lines table
 

--- a/src/tools/tslsym/Main.hs
+++ b/src/tools/tslsym/Main.hs
@@ -31,6 +31,8 @@ import Data.List (isInfixOf, partition)
 
 import Control.Monad (when)
 
+import Debug.Trace (trace)
+
 -----------------------------------------------------------------------------
 
 main
@@ -43,7 +45,7 @@ main = do
 
   spec <- loadTSL input
   let
-    table = toCSV $ symboltable spec
+    table = toCSV $ symboltable $ trace (show spec) spec
     (is,ts') = partition (isInfixOf "internal") es
     (h':es) = lines table
 

--- a/tsl.cabal
+++ b/tsl.cabal
@@ -100,6 +100,7 @@ library
     CoreGeneration.UnrealizabilityCores
     CoreGeneration.MinimalAssumptionCores
     CoreGeneration.FindFirstConcurrent
+    TSL.ModuloTheories.CFG
 
   hs-source-dirs:
     src/lib

--- a/tsl.cabal
+++ b/tsl.cabal
@@ -9,11 +9,13 @@ author:        Felix Klein <felix.klein@cispa.de>
                Philippe Heim <philippe.heim@cispa.de>
                Gideon Geier <gideon.geier@cispa.de>
                Marvin Stenger <marvin.stenger@cispa.de>
+               Wonhyuk Choi <wonhyuk.choi@columbia.edu>
 maintainer:    Felix Klein <felix.klein@cispa.de>
                Mark Santolucito <mark.santolucito@yale.edu>
                Philippe Heim <philippe.heim@cispa.de>
                Gideon Geier <gideon.geier@cispa.de>
                Marvin Stenger <marvin.stenger@cispa.de>
+               Wonhyuk Choi <wonhyuk.choi@columbia.edu>
 category:      Synthesis
 build-type:    Simple
 cabal-version: >=1.10
@@ -228,6 +230,39 @@ executable tsl2tlsf
 
   hs-source-dirs:
     src/tools/tsl2tlsf
+    src/tool-utilities
+
+  default-language:
+    Haskell2010
+
+executable tslmt2tsl
+
+  main-is:
+    Main.hs
+
+  other-modules:
+    PrintUtils
+    EncodingUtils
+    ArgParseUtils
+    FileUtils
+    Config
+
+  ghc-options:
+    -Wall
+    -Wno-name-shadowing
+    -fno-ignore-asserts
+
+  build-depends:
+      tsl
+    , base >=4.7 && <4.13
+    , directory >= 1.3
+    , filepath >= 1.4
+    , containers >=0.5 && <0.7
+    , ansi-terminal >= 0.6
+    , optparse-applicative
+
+  hs-source-dirs:
+    src/tools/tslmt2tsl
     src/tool-utilities
 
   default-language:


### PR DESCRIPTION
Partial Implementation of the tool `tslmt2tsl`.
Description is given in [documentation here](https://github.com/Barnard-PL-Labs/tsltools/blob/tslmt/docs/tslmt.md).

Currently, the tool is able to generate a Context-Free Grammar for cell & output terms via the flag `--cfg`.
All other flags are unimplemented.

The tool heavily leverages pre-existing data structures in `tsltools` such as `Specification`, `Formula`, `SymbolTable`, etc.