### PR TITLE
Add the `TSL.ModuloTheories.AST` datatype.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+deps
+specs
+local-dev
 *.tsl
 TODO
 .DS_Store

--- a/docs/tslmt.md
+++ b/docs/tslmt.md
@@ -18,6 +18,26 @@ However, as classic TSL is just TSL-MT with the Theory of Uninterpreted Function
 This allows TSL specifications (equivalently, TSL Modulo the Theory of Uninterpreted Functions) to _not underapproximate_ to Linear Temporal Logic (LTL) during synthesis as the TSL-MT synthesis procedure will capture the semantics of the update operator.
 More explanation is given in Example 4.3 of the [TSL-MT synthesis paper](https://www.marksantolucito.com/papers/pldi2022.pdf).
 
+## Installation
+In order to run `tslmt`, you will need a Satisfiability Modulo Theories (SMT) and Syntax-Guided Synthesis Solver (SyGuS) solver.
+The recommend solver is [CVC5](https://cvc5.github.io/).
+
+### Installing with CVC5
+First, you need to be in the top level directory (tsltools/.)
+
+Linux:
+```
+mkdir deps && cd deps
+wget https://github.com/cvc5/cvc5/releases/latest/download/cvc5-Linux -O cvc5
+chmod +x ./cvc5
+```
+MacOS:
+```
+mkdir deps && cd deps
+wget https://github.com/cvc5/cvc5/releases/latest/download/cvc5-macOS -O cvc5
+chmod +x ./cvc5
+```
+
 ## Supported first-order theories
 `tsltools` can support all first-order theories that a SyGuS solver can solve.
 However, we currently only have support for the following using [CVC5](https://cvc5.github.io/):

--- a/sample.tsl
+++ b/sample.tsl
@@ -1,1 +1,0 @@
-always assume {} always guarantee { [play <- noteG];}

--- a/src/lib/TSL/Logic.hs
+++ b/src/lib/TSL/Logic.hs
@@ -60,7 +60,7 @@ data SignalTerm a =
     Signal a
   | FunctionTerm (FunctionTerm a)
   | PredicateTerm (PredicateTerm a)
-  deriving (Eq, Ord)
+  deriving (Eq, Ord, Show)
 
 -----------------------------------------------------------------------------
 
@@ -76,11 +76,11 @@ instance Foldable SignalTerm where
     FunctionTerm t  -> foldr f a t
     PredicateTerm t -> foldr f a t
 
-instance Show a => Show (SignalTerm a) where
-  show = \case
-    Signal s        -> show s
-    FunctionTerm t  -> show t
-    PredicateTerm t -> show t
+-- instance Show a => Show (SignalTerm a) where
+--   show = \case
+--     Signal s        -> show s
+--     FunctionTerm t  -> show t
+--     PredicateTerm t -> show t
 
 instance Arbitrary a => Arbitrary (SignalTerm a) where
   arbitrary =
@@ -96,7 +96,7 @@ instance Arbitrary a => Arbitrary (SignalTerm a) where
 data FunctionTerm a =
     FunctionSymbol a
   | FApplied (FunctionTerm a) (SignalTerm a)
-  deriving (Eq, Ord)
+  deriving (Eq, Ord, Show)
 
 -----------------------------------------------------------------------------
 
@@ -110,10 +110,10 @@ instance Foldable FunctionTerm where
     FunctionSymbol s -> f s a
     FApplied t t'    -> foldr f (foldr f a t) t'
 
-instance Show a => Show (FunctionTerm a) where
-  show = \case
-    FunctionSymbol s -> show s
-    FApplied t t' -> show t ++ " " ++ show t'
+-- instance Show a => Show (FunctionTerm a) where
+--   show = \case
+--     FunctionSymbol s -> show s
+--     FApplied t t' -> show t ++ " " ++ show t'
 
 instance Arbitrary a => Arbitrary (FunctionTerm a) where
   arbitrary = do

--- a/src/lib/TSL/ModuloTheories/AST.hs
+++ b/src/lib/TSL/ModuloTheories/AST.hs
@@ -1,30 +1,90 @@
 -------------------------------------------------------------------------------
 -- |
 -- Module      :  TSL.ModuloTheories.AST
--- Description :  
+-- Description :  Abstract Syntax Tree form for signals, functions, and predicates.
 -- Maintainer  :  Wonhyuk Choi
---
+-- Alternate data structure format for ADT's in TSL.Logic.
+-- All signal/function/predicate Abstract Data Types in TSL.Logic are curried,
+-- and they need to transformed to a AST-style syntax in order to be
+-- fed into a SMT or SyGuS solver. 
+-- This module defines the AST type, and the transformative functions thereof.
 
 -------------------------------------------------------------------------------
 {-# LANGUAGE LambdaCase      #-}
 {-# LANGUAGE RecordWildCards #-}
 
 -------------------------------------------------------------------------------
-module TSL.ModuloTheories.AST
-  ) where
+module TSL.ModuloTheories.AST( AST
+                             , fromSignalTerm
+                             , fromFunctionTerm
+                             , fromPredicateTerm
+                             ) where
 
 -------------------------------------------------------------------------------
 
 import TSL.Logic ( Formula(..)
                  , SignalTerm(..)
+                 , FunctionTerm(..)
+                 , PredicateTerm(..)
                  )
 
-import Types(arity)
+import TSL.Types(ExprType(..))
 
 import TSL.Specification (Specification(..))
 
-import TSL.SymbolTable (Id, SymbolTable(..), Kind(..))
+import TSL.SymbolTable (Id)
 
 -------------------------------------------------------------------------------
 
-data AST = AST
+data AST a = Function a [AST a]
+
+instance Show a => Show (AST a) where
+  show = \case
+    (Function f []) -> show f
+    (Function f xs) -> "(" ++ show f ++ " " ++ (unwords (map show xs)) ++ ")"
+
+instance Functor AST where
+    fmap f (Function a as) = Function (f a) (map (fmap f) as)
+
+fromSignalTerm :: (a -> Int) -> SignalTerm a -> AST a
+fromSignalTerm arity = (fromList arity) . flattenS
+
+fromFunctionTerm :: (a -> Int) -> FunctionTerm a -> AST a
+fromFunctionTerm arity = (fromList arity) . flattenF
+
+fromPredicateTerm :: (a -> Int) -> PredicateTerm a -> AST a
+fromPredicateTerm arity = (fromList arity) . flattenP
+
+flattenS :: SignalTerm a -> [a]
+flattenS = \case
+  Signal a -> [a]
+  FunctionTerm f  -> flattenF f
+  PredicateTerm p -> flattenP p
+
+flattenF :: FunctionTerm a -> [a]
+flattenF = \case
+  FunctionSymbol a -> [a]
+  FApplied fterm s -> flattenF fterm ++ flattenS s
+
+flattenP :: PredicateTerm a -> [a]
+flattenP = \case
+  BooleanTrue       -> undefined -- Not Implemented
+  BooleanFalse      -> undefined -- Not Implemented
+  BooleanInput a    -> [a]
+  PredicateSymbol a -> [a]
+  PApplied pterm s  -> flattenP pterm ++ flattenS s
+
+fromList :: (a -> Int) -> [a] -> AST a
+fromList _ []         = undefined
+fromList arity (x:xs) = Function x args
+  where (args, _) = argBuilder arity (arity x) xs
+
+argBuilder :: (a -> Int) -> Int -> [a] -> ([AST a], [a])
+argBuilder _ 0 xs          = ([], xs)
+argBuilder _ _ []          = undefined
+argBuilder arity n (x:xs)  = (args, remainder)
+  where 
+    args     = argsHead:argsTail
+    argsHead = Function x headArgs
+    (argsTail, remainder)  = argBuilder arity (n-1) remainder'
+    (headArgs, remainder') = argBuilder arity (arity x) xs

--- a/src/lib/TSL/ModuloTheories/PredicateList.hs
+++ b/src/lib/TSL/ModuloTheories/PredicateList.hs
@@ -15,17 +15,24 @@ module TSL.ModuloTheories.PredicateList(getPredicateTerms) where
 
 import TSL.Specification(Specification(..))
 
-import TSL.SymbolTable(Id)
+import TSL.SymbolTable(Id, SymbolTable(..))
+
+import TSL.Types(arity)
 
 import TSL.Logic( Formula(..)
                 , PredicateTerm(..)
                 , foldFormula
                 )
 
+import TSL.ModuloTheories.AST(AST, fromPredicateTerm)
+
 -------------------------------------------------------------------------------
 
-getPredicateTerms :: Specification -> [PredicateTerm Id]
-getPredicateTerms (Specification a g _) = (fromFList a []) ++ (fromFList g [])
+getPredicateTerms :: Specification -> [AST Id]
+getPredicateTerms (Specification a g s) = map fromPTerm pTerms
+  where 
+    pTerms    = (fromFList a []) ++ (fromFList g [])
+    fromPTerm = fromPredicateTerm (arity . (stType s))
 
 fromFList :: [Formula a] -> [PredicateTerm a] -> [PredicateTerm a]
 fromFList [] ps     = ps

--- a/tsl.cabal
+++ b/tsl.cabal
@@ -100,6 +100,7 @@ library
     CoreGeneration.UnrealizabilityCores
     CoreGeneration.MinimalAssumptionCores
     CoreGeneration.FindFirstConcurrent
+    TSL.ModuloTheories.AST
     TSL.ModuloTheories.CFG
     TSL.ModuloTheories.PredicateList
 


### PR DESCRIPTION
All signal/function/predicate Abstract Data Types in `TSL.Logic` are curried, and they need to transformed to a AST-style syntax in order to be fed into a SMT or SyGuS solver.
`TSL.ModuloThoeries.AST` defines the AST type, and the transformative functions thereof.