### PR TITLE
Pass formula to ltlsynt via STDIN instead of arg

### DIFF
--- a/src/TSL/LTL.hs
+++ b/src/TSL/LTL.hs
@@ -43,14 +43,14 @@ synthesize' ltlsyntPath tlsfContents = do
       ltlOuts = prOutputs S.defaultCfg tlsfSpec
       ltlFormulae = prFormulae S.defaultCfg {S.outputMode = S.Fully, S.outputFormat = S.LTLXBA} tlsfSpec
       ltlCommandArgs =
-        [ "--formula=" ++ ltlFormulae,
+        [ "--file=-",
           "--ins=" ++ ltlIns,
           "--outs=" ++ ltlOuts,
           "--hoaf=i"
         ]
 
   -- call ltlsynt
-  readProcessWithExitCode ltlsyntPath ltlCommandArgs ""
+  readProcessWithExitCode ltlsyntPath ltlCommandArgs ltlFormulae
   where
     prFormulae ::
       S.Configuration -> S.Specification -> String


### PR DESCRIPTION
On Linux the maximum size of the command line is limited.
This limits the size of the formula tsltools can pass to ltlsynt.
Passing the formula via STDIN circumvents this limit.